### PR TITLE
Fix crash on startup due to missing module initialization.

### DIFF
--- a/widgets.py
+++ b/widgets.py
@@ -204,6 +204,7 @@ class ExportButtonFactory():
 class DocumentView(Abi.Widget):
 
     def __init__(self):
+        Abi.init([])
         Abi.Widget.__init__(self)
         self.connect('size-allocate', self.__size_allocate_cb)
         try:


### PR DESCRIPTION
This bug has been found in Debian, and documented in:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=791549

Patch can be found in Debian bugtracker as well.

Severity: Grave
Write is unusable in Debian without attached patch.